### PR TITLE
Add tags

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci && npm install -g markdownlint-cli
 
       - name: Check lint
-        run: npm lint
+        run: npm run lint

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -14,6 +14,7 @@
       </div>
 
       <div class="footer-col footer-col-3">
+        <span class="title">SHAPING YOUR IDEAS IN THE CLOUD</span>
       </div>
   </div>
 

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -18,7 +18,7 @@ layout: default
       {%- if page.tags -%}
         <span class="tags">
           {%- for tag in page.tags -%}
-            <span class="tag" itemprop="name">{{ tag | replace '["', '' }}</span>
+            <span class="tag" itemprop="name">{{ tag }}</span>
           {%- endfor -%}
         </span>
       {%- endif -%}</p>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -10,8 +10,17 @@ layout: default
         {%- assign date_format = site.minima.date_format | default: "%b %-d, %Y" -%}
         {{ page.date | date: date_format }}
       </time>
+
       {%- if page.author -%}
         • <span itemprop="author" itemscope itemtype="http://schema.org/Person"><span class="p-author h-card" itemprop="name">{{ page.author }}</span></span>
+      {%- endif -%}
+
+      {%- if page.tags -%}
+        <span class="tags">
+          {%- for tag in page.tags -%}
+            <span class="tag" itemprop="name">{{ tag | replace '["', '' }}</span>
+          {%- endfor -%}
+        </span>
       {%- endif -%}</p>
   </header>
 

--- a/_posts/2021-09-28-redux-saga-with-callback.md
+++ b/_posts/2021-09-28-redux-saga-with-callback.md
@@ -2,6 +2,10 @@
 layout: post
 title:  "How to use Redux-Saga effects within a callback"
 author: "Xavier Balloy"
+tags: 
+  - javascript
+  - react 
+  - saga
 ---
 Because you can only add a `yield` expression in a generator body it can be tricky
 to use a callback-based library in your saga (a generator function).

--- a/_sass/minima/_layout.scss
+++ b/_sass/minima/_layout.scss
@@ -144,6 +144,12 @@
 .footer-col-3 {
   width: -webkit-calc(45% - (#{$spacing-unit} / 2));
   width:         calc(45% - (#{$spacing-unit} / 2));
+
+  .title {
+    display: flex;
+    align-items: flex-end;
+    justify-content: flex-end;
+  }
 }
 
 @include media-query($on-laptop) {

--- a/_sass/minima/_layout.scss
+++ b/_sass/minima/_layout.scss
@@ -203,6 +203,19 @@
 .post-meta {
   font-size: $small-font-size;
   color: $grey-color;
+
+  .tags {
+    display: flex;
+    align-content: space-between;
+    gap: 5px;
+    
+    .tag {
+      background: $grey-color;
+      border-radius: 5px;
+      color: white;
+      padding: 0px 5px 0px 5px;
+    }
+  }
 }
 
 .post-link {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "version": "1.0.0",
       "license": "UNLICENSED",
       "dependencies": {
-        "markdownlint": "^0.24.0"
+        "markdownlint": "0.24.0"
       }
     },
     "node_modules/argparse": {


### PR DESCRIPTION
We're adding tags here, displayed right below the date and author information for each post detail page.

Note: I also fixed the build as `markdownlint` was not available on Github CI (had the same issue locally but saw it only after it failed here)

Closes issue #3 

---
Looks like this:
![Screenshot from 2021-10-04 21-36-09](https://user-images.githubusercontent.com/16050894/135946847-efc9159f-3cd7-43ea-b442-d331c818f957.png)

