### PR TITLE
build: add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,0 +1,8 @@
+pull_request_rules:
+  - name: Automatic merge for Dependabot pull requests
+    conditions:
+      - author=dependabot[bot]
+      - check-success=Build and test
+    actions:
+      merge:
+        method: squash

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -5,7 +5,10 @@ on:
 
 jobs:
   build_and_test:
+    name: Build and test
+
     runs-on: ubuntu-20.04
+
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
Because we don't want to manually update the dependencies ¯\_(ツ)_/¯
